### PR TITLE
Correct configmap

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -54,5 +54,5 @@ metadata:
   name: rsync-ssh-users
 data:
   GROUPID: "{{ .Values.rsync.groupId }}"
-  GITHUB_USERS: "{{- range $e := .Values.rsync.githubUsers }} {{ . }} {{- end }}
-{{- end }}"
+  GITHUB_USERS: "{{- range $e := .Values.rsync.githubUsers }} {{ . }} {{- end }}"
+{{- end }}


### PR DESCRIPTION
Trying to fix the error:
```
---
Error: YAML parse error on vsftpd-anonymous-upload/templates/configmap.yaml: error converting YAML to JSON: yaml: found unexpected end of stream
helm.go:81: [debug] error converting YAML to JSON: yaml: found unexpected end of stream
YAML parse error on vsftpd-anonymous-upload/templates/configmap.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
	/private/tmp/helm-20210310-44407-1006esy/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
	/private/tmp/helm-20210310-44407-1006esy/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
	/private/tmp/helm-20210310-44407-1006esy/pkg/action/action.go:165
helm.sh/helm/v3/pkg/action.(*Install).Run
	/private/tmp/helm-20210310-44407-1006esy/pkg/action/install.go:240
main.runInstall
	/private/tmp/helm-20210310-44407-1006esy/cmd/helm/install.go:242
main.newTemplateCmd.func2
	/private/tmp/helm-20210310-44407-1006esy/cmd/helm/template.go:73
github.com/spf13/cobra.(*Command).execute
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main
	/private/tmp/helm-20210310-44407-1006esy/cmd/helm/helm.go:80
runtime.main
	/usr/local/Cellar/go/1.16/libexec/src/runtime/proc.go:225
runtime.goexit
	/usr/local/Cellar/go/1.16/libexec/src/runtime/asm_amd64.s:1371
```